### PR TITLE
fix: build issue due to outdated nodeenv

### DIFF
--- a/changelog.d/20231121_114409_regis_fix_nodeenv.md
+++ b/changelog.d/20231121_114409_regis_fix_nodeenv.md
@@ -1,0 +1,1 @@
+- [Bugfix] Fix build error due to outdated nodeenv. (by @regisb)

--- a/tutorcredentials/templates/credentials/build/credentials/Dockerfile
+++ b/tutorcredentials/templates/credentials/build/credentials/Dockerfile
@@ -106,8 +106,8 @@ FROM python as nodejs-requirements
 ENV PATH /openedx/nodeenv/bin:/openedx/venv/bin:${PATH}
 
 # Install nodeenv with the version provided by credentials
-# https://github.com/pyenv/pyenv/releases
-RUN pip install nodeenv==1.7.0
+# https://github.com/ekalinin/nodeenv/releases
+RUN pip install nodeenv==1.8.0
 RUN nodeenv /openedx/nodeenv --node=16.14.0 --prebuilt
 
 # Install nodejs requirements


### PR DESCRIPTION
We were sometimes facing the following issue during build:

	171.0 Traceback (most recent call last):
	171.0   File "/openedx/venv/bin/nodeenv", line 8, in <module>
	171.0     sys.exit(main())
	171.0   File "/openedx/venv/lib/python3.8/site-packages/nodeenv.py",
	    line 1104, in main
	171.0     create_environment(env_dir, args)
	171.0   File "/openedx/venv/lib/python3.8/site-packages/nodeenv.py",
	    line 980, in create_environment
	171.0     install_node(env_dir, src_dir, args)
	171.0   File "/openedx/venv/lib/python3.8/site-packages/nodeenv.py",
	    line 739, in install_node
	171.0     install_node_wrapped(env_dir, src_dir, args)
	171.0   File "/openedx/venv/lib/python3.8/site-packages/nodeenv.py",
	    line 762, in install_node_wrapped
	171.0     download_node_src(node_url, src_dir, args)
	171.0   File "/openedx/venv/lib/python3.8/site-packages/nodeenv.py",
	    line 602, in download_node_src
	171.0     with ctx as archive:
	171.0   File "/opt/pyenv/versions/3.8.15/lib/python3.8/contextlib.py",
	    line 113, in __enter__
	171.0     return next(self.gen)
	171.0   File "/openedx/venv/lib/python3.8/site-packages/nodeenv.py",
	    line 573, in tarfile_open
	171.0     tf = tarfile.open(*args, **kwargs)
	171.0   File "/opt/pyenv/versions/3.8.15/lib/python3.8/tarfile.py", line
	    1601, in open
	171.0     saved_pos = fileobj.tell()
	171.0 AttributeError: 'bytes' object has no attribute 'tell'

This is an issue that is caused by some network failure and is incorrectly managed by nodeenv 1.7.0. We reolve the issue (in some cases) by upgrading nodeenv.