### PR TITLE
fix: add url slash for production services

### DIFF
--- a/tutorcredentials/templates/credentials/tasks/credentials/init
+++ b/tutorcredentials/templates/credentials/tasks/credentials/init
@@ -7,13 +7,13 @@ echo "credentials service - ./manage.py migrate create_or_update_site"
   --site-domain "{{ CREDENTIALS_HOST }}" \
   --site-name "{{ LMS_HOST }}" \
   --platform-name "{{ PLATFORM_NAME }}" \
-  --lms-url-root "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}{{ LMS_HOST }}" \
-  --catalog-api-url "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}{{ DISCOVERY_HOST }}/api/v1/" \
-  --tos-url "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}{{ LMS_HOST }}/tos" \
-  --privacy-policy-url "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}{{ LMS_HOST }}/privacy-policy" \
-  --homepage-url "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}{{ LMS_HOST }}" \
+  --lms-url-root "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ LMS_HOST }}" \
+  --catalog-api-url "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ DISCOVERY_HOST }}/api/v1/" \
+  --tos-url "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ LMS_HOST }}/tos" \
+  --privacy-policy-url "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ LMS_HOST }}/privacy-policy" \
+  --homepage-url "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ LMS_HOST }}" \
   --company-name "{{ PLATFORM_NAME }}" \
-  --certificate-help-url "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}{{ LMS_HOST }}" \
+  --certificate-help-url "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ LMS_HOST }}" \
   --theme-name "{{ CREDENTIALS_THEME_NAME }}"
 
 # for development


### PR DESCRIPTION
Fixes #30.

- `://` were missing in the service urls for production as mentioned by @DawoudSheraz [here](https://github.com/overhangio/tutor-credentials/issues/30#issuecomment-1897919304). Added those.