### PR TITLE
Add mounts for docker-compose-dev-services

### DIFF
--- a/changelog.d/20240220_124357_cmltawt0_mounts.md
+++ b/changelog.d/20240220_124357_cmltawt0_mounts.md
@@ -1,0 +1,1 @@
+- [Feature] Make it possible to use mounts for a local development. (by @cmltawt0)

--- a/tutorcredentials/patches/local-docker-compose-dev-services
+++ b/tutorcredentials/patches/local-docker-compose-dev-services
@@ -9,6 +9,9 @@ credentials:
   volumes:
     # editable requirements
     - ../plugins/credentials/build/credentials/requirements:/openedx/requirements
+    {%- for mount in iter_mounts(MOUNTS, "credentials") %}
+    - {{ mount }}
+    {%- endfor %}
   networks:
     default:
       aliases:


### PR DESCRIPTION
This PR is adding the ability to do a local development for credentials.

I am trying to use the plugin for local development but the process of adding mounts doesn't work for me.
Am I missing something or mounts should be considered in `local-docker-compose-dev-services`?

--

How to test:
```
cat ./root/env/dev/docker-compose.yml
...
  credentials:
    environment:
      DJANGO_SETTINGS_MODULE: credentials.settings.tutor.development
    command: ./manage.py runserver 0.0.0.0:8150
    ports:
      - "127.0.0.1:8150:8150"
    stdin_open: true
    tty: true
    volumes:
      # editable requirements
      - ../plugins/credentials/build/credentials/requirements:/openedx/requirements
    networks:
      default:
        aliases:
          - "credentials.local.edly.io"
...
```

```sh
tutor mounts add ./src/credentials
```

```
cat ./root/env/dev/docker-compose.yml
...
  credentials:
    environment:
      DJANGO_SETTINGS_MODULE: credentials.settings.tutor.development
    command: ./manage.py runserver 0.0.0.0:8150
    ports:
      - "127.0.0.1:8150:8150"
    stdin_open: true
    tty: true
    volumes:
      # editable requirements
      - ../plugins/credentials/build/credentials/requirements:/openedx/requirements
      - /Users/cmltawt0/code/boxes/nightly/src/credentials:/openedx/credentials
    networks:
      default:
        aliases:
          - "credentials.local.edly.io"
...
```

The same effect we can achieve by manually removing our mount from `./root/env/dev/docker-compose.yml` and then invoking config save command:
```
tutor config save
```

```
cat ./root/env/dev/docker-compose.yml
...
  credentials:
    environment:
      DJANGO_SETTINGS_MODULE: credentials.settings.tutor.development
    command: ./manage.py runserver 0.0.0.0:8150
    ports:
      - "127.0.0.1:8150:8150"
    stdin_open: true
    tty: true
    volumes:
      # editable requirements
      - ../plugins/credentials/build/credentials/requirements:/openedx/requirements
      - /Users/cmltawt0/code/boxes/nightly/src/credentials:/openedx/credentials
    networks:
      default:
        aliases:
          - "credentials.local.edly.io"
...
```


---
I'll test against `master` branch and post command to make it works with all console output.
Then change the DRAFT status to ready.