### PR TITLE
Enhancement: Python 3.11 upgrade

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,6 +4,7 @@ variables:
     TUTOR_PYPI_PACKAGE: tutor-credentials
     GITHUB_REPO: overhangio/tutor-credentials
     TUTOR_EXTRA_ENABLED_PLUGINS: discovery mfe
+    IMAGES_BUILD_PLATFORM: "linux/amd64"
 
 include:
   - project: 'community/tutor-ci'

--- a/changelog.d/20240508_141227_faraz.maqsood_python_upgrade_to_v3_11_9.md
+++ b/changelog.d/20240508_141227_faraz.maqsood_python_upgrade_to_v3_11_9.md
@@ -1,0 +1,1 @@
+- 💥[Feature] Upgrade Python version to 3.11.9. (by @Faraz32123)

--- a/tutorcredentials/templates/credentials/build/credentials/Dockerfile
+++ b/tutorcredentials/templates/credentials/build/credentials/Dockerfile
@@ -1,7 +1,6 @@
 # syntax=docker/dockerfile:1
 ###### Minimal image with base system requirements for most stages
 FROM docker.io/ubuntu:20.04 as minimal
-LABEL maintainer="Lawrence McDaniel <lpm0073@gmail.com>"
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \

--- a/tutorcredentials/templates/credentials/build/credentials/Dockerfile
+++ b/tutorcredentials/templates/credentials/build/credentials/Dockerfile
@@ -25,9 +25,9 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 # Install pyenv
 # https://www.python.org/downloads/
 # https://github.com/pyenv/pyenv/releases
-ARG PYTHON_VERSION=3.8.18
+ARG PYTHON_VERSION=3.11.9
 ENV PYENV_ROOT /opt/pyenv
-RUN git clone https://github.com/pyenv/pyenv $PYENV_ROOT --branch v2.3.29 --depth 1
+RUN git clone https://github.com/pyenv/pyenv $PYENV_ROOT --branch v2.4.0 --depth 1
 
 # Install Python
 RUN $PYENV_ROOT/bin/pyenv install $PYTHON_VERSION
@@ -39,8 +39,8 @@ RUN $PYENV_ROOT/versions/$PYTHON_VERSION/bin/python -m venv /openedx/venv
 FROM minimal as code
 ARG CREDENTIALS_REPOSITORY="{{ CREDENTIALS_REPOSITORY }}"
 ARG CREDENTIALS_VERSION="{{ CREDENTIALS_REPOSITORY_VERSION }}"
-RUN mkdir -p /openedx/credentials
-ADD --keep-git-dir=true $CREDENTIALS_REPOSITORY#$CREDENTIALS_VERSION /openedx/credentials
+RUN mkdir -p /openedx/credentials && \
+    git clone $CREDENTIALS_REPOSITORY --branch $CREDENTIALS_VERSION --depth 1 /openedx/credentials
 WORKDIR /openedx/credentials
 
 {{ patch("credentials-dockerfile-post-git-checkout") }}
@@ -65,7 +65,7 @@ RUN --mount=type=cache,target=/openedx/.cache/pip,sharing=shared pip install \
     # https://pypi.org/project/setuptools/
     # https://pypi.org/project/pip/
     # https://pypi.org/project/wheel/
-    setuptools==68.2.2 pip==23.2.1. wheel==0.41.2
+    setuptools==69.1.1 pip==24.0 wheel==0.43.0
 
 # Install base requirements
 RUN --mount=type=cache,target=/openedx/.cache/pip,sharing=shared pip install -r requirements/production.txt
@@ -75,7 +75,7 @@ RUN --mount=type=cache,target=/openedx/.cache/pip,sharing=shared pip install \
     # Use redis as a django cache https://pypi.org/project/django-redis/
     django-redis==5.4.0 \
     # uwsgi server https://pypi.org/project/uWSGI/
-    uwsgi==2.0.22
+    uwsgi==2.0.24
 
 {{ patch("credentials-dockerfile-post-python-requirements") }}
 
@@ -89,7 +89,7 @@ ENV PATH /openedx/nodeenv/bin:/openedx/venv/bin:${PATH}
 # Install nodeenv with the version provided by credentials
 # https://github.com/ekalinin/nodeenv/releases
 RUN pip install nodeenv==1.8.0
-RUN nodeenv /openedx/nodeenv --node=16.14.0 --prebuilt
+RUN nodeenv /openedx/nodeenv --node=16.14.2 --prebuilt
 
 # Install nodejs requirements
 ARG NPM_REGISTRY='{{ NPM_REGISTRY }}'


### PR DESCRIPTION
close #34 
NOTES: 
- [Credentials](https://github.com/openedx/credentials/) codebase is not compatible with python3.12 yet. 
- CI: temporarily skipping building on arm64. As the upstream credentials repo seems to be breaking on arm64 and they are skipping arm64 builds as well due to the didkit package dependency not available on arm64 yet.
