### PR TITLE
fix: custom image pull and push

### DIFF
--- a/changelog.d/20240607_105741_evgen.dyudyunov_fix_image_push.md
+++ b/changelog.d/20240607_105741_evgen.dyudyunov_fix_image_push.md
@@ -1,0 +1,1 @@
+- [BugFix] Fix custom image pull/push. (by @dyudyunov)

--- a/tutorcredentials/plugin.py
+++ b/tutorcredentials/plugin.py
@@ -167,6 +167,18 @@ tutor_hooks.Filters.IMAGES_BUILD.add_item(
         (),
     )
 )
+tutor_hooks.Filters.IMAGES_PULL.add_item(
+    (
+        "credentials",
+        "{{ CREDENTIALS_DOCKER_IMAGE }}",
+    )
+)
+tutor_hooks.Filters.IMAGES_PUSH.add_item(
+    (
+        "credentials",
+        "{{ CREDENTIALS_DOCKER_IMAGE }}",
+    )
+)
 
 
 ########################################


### PR DESCRIPTION
Allow custom images for pull/push.

By default, the image name is "credentials" so if you build your image named `{{ CREDENTIALS_DOCKER_IMAGE }}` - you'll get an error "image {{ CREDENTIALS_DOCKER_IMAGE }} not found".