### PR TITLE
feat: ubuntu upgrade

### DIFF
--- a/changelog.d/20241010_175810_faraz.maqsood_ubuntu_upgrade.md
+++ b/changelog.d/20241010_175810_faraz.maqsood_ubuntu_upgrade.md
@@ -1,0 +1,3 @@
+- 💥[Feature] Update Credentials Image to use Ubuntu `24.04` as base OS. (by @Faraz32123)
+  - Add `mime-support` alternatives that are `media-types mailcap`.
+  - Update `python-openssl` to `python3-openssl`.

--- a/tutorcredentials/templates/credentials/build/credentials/Dockerfile
+++ b/tutorcredentials/templates/credentials/build/credentials/Dockerfile
@@ -1,8 +1,12 @@
 # syntax=docker/dockerfile:1
 ###### Minimal image with base system requirements for most stages
-FROM docker.io/ubuntu:20.04 AS minimal
+FROM docker.io/ubuntu:24.04 AS minimal
 
 ENV DEBIAN_FRONTEND=noninteractive
+
+# Delete default UID=1000 `ubuntu` user to ensure we can use id 1000 for app user
+RUN userdel -r ubuntu
+
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
     apt update && \
@@ -11,7 +15,6 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 ENV LC_ALL=en_US.UTF-8
 {{ patch("credentials-dockerfile-minimal") }}
 
-
 ###### Install python with pyenv in /opt/pyenv and create virtualenv in /openedx/venv
 FROM minimal AS python
 # https://github.com/pyenv/pyenv/wiki/Common-build-problems#prerequisites
@@ -19,7 +22,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked apt update && \
     apt install -y libssl-dev zlib1g-dev libbz2-dev \
     libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
-    xz-utils tk-dev libffi-dev liblzma-dev python-openssl git
+    xz-utils tk-dev libffi-dev liblzma-dev python3-openssl git
 
 # Install pyenv
 # https://www.python.org/downloads/
@@ -36,6 +39,9 @@ RUN $PYENV_ROOT/versions/$PYTHON_VERSION/bin/python -m venv /openedx/venv
 
 ###### Checkout credentials
 FROM minimal AS code
+# Below warnings will occurr due to the variable name(have word "credentials" in it).
+# - SecretsUsedInArgOrEnv: Do not use ARG or ENV instructions for sensitive data (ARG "CREDENTIALS_REPOSITORY") (line 41)
+# - SecretsUsedInArgOrEnv: Do not use ARG or ENV instructions for sensitive data (ARG "CREDENTIALS_VERSION") (line 42)
 ARG CREDENTIALS_REPOSITORY="{{ CREDENTIALS_REPOSITORY }}"
 ARG CREDENTIALS_VERSION="{{ CREDENTIALS_REPOSITORY_VERSION }}"
 RUN mkdir -p /openedx/credentials && \
@@ -102,7 +108,7 @@ FROM minimal AS production
 # Install system requirements
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked apt update \
-    && apt install -y libxml2 libmysqlclient-dev mime-support
+    && apt install -y libxml2 libmysqlclient-dev media-types mailcap
 
 # From then on, run as unprivileged "app" user
 ARG APP_USER_ID=1000
@@ -110,7 +116,7 @@ RUN if [ "$APP_USER_ID" = 0 ]; then echo "app user may not be root" && false; fi
 RUN useradd --home-dir /openedx --create-home --shell /bin/bash --uid ${APP_USER_ID} app
 USER ${APP_USER_ID}
 
-# change file ownership to the new app user
+# Change file ownership to the new app user
 COPY --chown=app:app --from=code /openedx/credentials /openedx/credentials
 COPY --chown=app:app --from=python /opt/pyenv /opt/pyenv
 COPY --chown=app:app --from=python-requirements /openedx/venv /openedx/venv
@@ -129,6 +135,8 @@ RUN python manage.py compilemessages
 
 # Setup minimal yml config file, which is required by production settings
 RUN echo "{}" > /openedx/config.yml
+# Below warning will occurr due to the variable name(have word "credentials" in it).
+# - SecretsUsedInArgOrEnv: Do not use ARG or ENV instructions for sensitive data (ENV "CREDENTIALS_CFG") (line 136)
 ENV CREDENTIALS_CFG=/openedx/config.yml
 
 {{ patch("credentials-dockerfile-pre-assets") }}
@@ -152,13 +160,13 @@ EXPOSE 8000
 ###### Final image with production cmd
 FROM production AS final
 
-CMD uwsgi \
-    --static-map /static=/openedx/credentials/credentials/assets \
-    --static-map /media=/openedx/credentials/credentials/media \
-    --http 0.0.0.0:8000 \
-    --thunder-lock \
-    --single-interpreter \
-    --enable-threads \
-    --processes=${UWSGI_WORKERS:-2} \
-    --buffer-size=8192 \
-    --wsgi-file credentials/wsgi.py
+CMD ["uwsgi", \
+    "--static-map", "/static=/openedx/credentials/credentials/assets", \
+    "--static-map", "/media=/openedx/credentials/credentials/media", \
+    "--http", "0.0.0.0:8000", \
+    "--thunder-lock", \
+    "--single-interpreter", \
+    "--enable-threads", \
+    "--processes=${UWSGI_WORKERS:-2}", \
+    "--buffer-size=8192", \
+    "--wsgi-file", "credentials/wsgi.py"]


### PR DESCRIPTION
- Update Credentials Image to use Ubuntu `24.04` as base OS.
- Add `mime-support` alternatives that are `media-types mailcap`.
- Update `python-openssl` to `python3-openssl`.
- add changelog entry.
- close #45