### PR TITLE
chore: revert change that skip arm64 image build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,8 +3,7 @@ variables:
     TUTOR_IMAGES: credentials
     TUTOR_PYPI_PACKAGE: tutor-credentials
     GITHUB_REPO: overhangio/tutor-credentials
-    TUTOR_EXTRA_ENABLED_PLUGINS: discovery mfe
-    IMAGES_BUILD_PLATFORM: "linux/amd64"
+    TUTOR_EXTRA_ENABLED_PLUGINS: discovery mfe 
 
 include:
   - project: 'community/tutor-ci'


### PR DESCRIPTION
- As didkit issue is resolved in latest version which is being used in upstream credential repo. So, reverting this change. 
For context, see this comment: https://github.com/overhangio/tutor-credentials/issues/34#issuecomment-2291001545