### PR TITLE
chore: revert change that skip arm64 image build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,8 +3,7 @@ variables:
     TUTOR_IMAGES: credentials
     TUTOR_PYPI_PACKAGE: tutor-credentials
     GITHUB_REPO: overhangio/tutor-credentials
-    TUTOR_EXTRA_ENABLED_PLUGINS: discovery mfe
-    IMAGES_BUILD_PLATFORM: "linux/amd64"
+    TUTOR_EXTRA_ENABLED_PLUGINS: discovery mfe 
 
 include:
   - project: 'community/tutor-ci'


### PR DESCRIPTION
In this PR, `IMAGES_BUILD_PLATFORM` setting is removed. This setting was initially added to prevent the credentials image from being built for `arm64` due to issues with the didkit package on `arm64` machines. Now, the image can be built for both amd64 and arm64 architectures.

This commit is already merged in nightly in this [PR](https://github.com/overhangio/tutor-credentials/pull/47) for sumac.
And this PR is made for redwood. Once redwood.3 is available, this PR will be merged.
