### PR TITLE
Fix: uwsgi workers not starting properly

### DIFF
--- a/changelog.d/20241022_194734_faraz.maqsood_uwsgi_workers_not_starting_properly.md
+++ b/changelog.d/20241022_194734_faraz.maqsood_uwsgi_workers_not_starting_properly.md
@@ -1,0 +1,1 @@
+- [BugFix] Uwsgi workers wasn't starting properly using `UWSGI_WORKERS` flag, passing the value directly fixes the issue. (by @Faraz32123)

--- a/tutorcredentials/templates/credentials/build/credentials/Dockerfile
+++ b/tutorcredentials/templates/credentials/build/credentials/Dockerfile
@@ -167,6 +167,6 @@ CMD ["uwsgi", \
     "--thunder-lock", \
     "--single-interpreter", \
     "--enable-threads", \
-    "--processes=${UWSGI_WORKERS:-2}", \
+    "--processes=2", \ 
     "--buffer-size=8192", \
     "--wsgi-file", "credentials/wsgi.py"]


### PR DESCRIPTION
Uwsgi workers wasn't starting properly using `UWSGI_WORKERS` flag, passing the value directly fixes the issue.
error logs:
```
2024-10-22 17:58:52 [uwsgi-static] added mapping for /static => /openedx/credentials/credentials/assets
2024-10-22 17:58:52 [uwsgi-static] added mapping for /media => /openedx/credentials/credentials/media
2024-10-22 17:58:52 *** Starting uWSGI 2.0.24 (64bit) on [Tue Oct 22 12:58:52 2024] ***
2024-10-22 17:58:52 compiled with version: 13.2.0 on 17 October 2024 10:37:05
2024-10-22 17:58:52 os: Linux-6.5.11-linuxkit #1 SMP PREEMPT_DYNAMIC Mon Dec  4 10:03:25 UTC 2023
2024-10-22 17:58:52 nodename: 7a34710d8562
2024-10-22 17:58:52 machine: x86_64
2024-10-22 17:58:52 clock source: unix
2024-10-22 17:58:52 detected number of CPU cores: 16
2024-10-22 17:58:52 current working directory: /openedx/credentials
2024-10-22 17:58:52 detected binary path: /openedx/venv/bin/uwsgi
2024-10-22 17:58:52 !!! no internal routing support, rebuild with pcre support !!!
2024-10-22 17:58:52 *** WARNING: you are running uWSGI without its master process manager ***
2024-10-22 17:58:52 your memory page size is 4096 bytes
2024-10-22 17:58:52 detected max file descriptor number: 1048576
2024-10-22 17:58:52 building mime-types dictionary from file /etc/mime.types...1560 entry found
2024-10-22 17:58:52 lock engine: pthread robust mutexes
2024-10-22 17:58:52 thunder lock: enabled
2024-10-22 17:58:52 uWSGI http bound on 0.0.0.0:8000 fd 4
2024-10-22 17:58:52 spawned uWSGI http 1 (pid: 7)
2024-10-22 17:58:52 uwsgi socket 0 bound to TCP address 127.0.0.1:40863 (port auto-assigned) fd 3
2024-10-22 17:58:52 Python version: 3.11.9 (main, Oct 17 2024, 10:31:00) [GCC 13.2.0]
2024-10-22 17:58:52 Python main interpreter initialized at 0x7f2eb35b86b8
2024-10-22 17:58:52 python threads support enabled
2024-10-22 17:58:52 your server socket listen backlog is limited to 100 connections
2024-10-22 17:58:52 your mercy for graceful operations on workers is 60 seconds
2024-10-22 17:58:52 *** Operational MODE: no-workers ***
2024-10-22 17:58:53 WSGI app 0 (mountpoint='') ready in 1 seconds on interpreter 0x7f2eb35b86b8 pid: 1 (default app)
```