### PR TITLE
Update sync_users

### DIFF
--- a/changelog.d/fix-mysql-concat.md
+++ b/changelog.d/fix-mysql-concat.md
@@ -1,0 +1,2 @@
+- [Bugfix] Fixed an issue when syncing `credentials.core_user` to `openedx.auth_user` where the `full_name` field population failed with `ERROR 1292 (22007): Truncated incorrect DOUBLE value: 'FirstName'`.  
+  MySQL does not support string concatenation with `+`, so it was incorrectly treated as a numeric operation. Updated to use `CONCAT()` for proper string concatenation.

--- a/tutorcredentials/templates/credentials/tasks/mysql/sync_users
+++ b/tutorcredentials/templates/credentials/tasks/mysql/sync_users
@@ -11,7 +11,7 @@ INSERT {{ CREDENTIALS_MYSQL_DATABASE }}.core_user (password, last_login, is_supe
                lms_user.is_staff, \
                lms_user.is_active, \
                lms_user.date_joined, \
-               CASE WHEN NOT ISNULL(lms_profile.name) THEN lms_profile.name ELSE lms_user.first_name + ' ' + lms_user.last_name END as full_name, \
+               CASE WHEN NOT ISNULL(lms_profile.name) THEN lms_profile.name ELSE CONCAT(lms_user.first_name, ' ', lms_user.last_name) END as full_name, \
                lms_user.id as lms_user_id \
      FROM      {{ OPENEDX_MYSQL_DATABASE }}.auth_user lms_user \
                LEFT JOIN {{ OPENEDX_MYSQL_DATABASE }}.auth_userprofile as lms_profile ON (lms_user.id = lms_profile.user_id) \


### PR DESCRIPTION
fix issue during `sync credentials.core_user to openedx.auth_user` failing with error: `ERROR 1292 (22007) at line 1: Truncated incorrect DOUBLE value: 'FirstName'` when the ELSE statement gets triggered in the `full_name` field population

MySQL does not use '+' to concatenate strings so it was incorrectly treated as a math equation instead. Updated to use the correct CONCAT function