### PR TITLE
fix: add critical fix for vc flow in Ulmo

### DIFF
--- a/changelog.d/20260401_164245_glugovgrglib_openedx_dep_update.md
+++ b/changelog.d/20260401_164245_glugovgrglib_openedx_dep_update.md
@@ -1,0 +1,1 @@
+- [Bugfix] Add patch with the package update of vc (verifiable credentials) signining lib to openedx fork that is necessary for the vc sharing flow(https://github.com/openedx/credentials/issues/2956). (by @GlugovGrGlib)

--- a/tutorcredentials/templates/credentials/build/credentials/Dockerfile
+++ b/tutorcredentials/templates/credentials/build/credentials/Dockerfile
@@ -56,6 +56,8 @@ RUN git config --global user.email "tutor@overhang.io" \
 RUN curl -fsSL https://github.com/openedx/credentials/commit/0b66761d681faf9e8df5f63c0e26334d93105aa0.patch | git am
 ## Update obv3 achievement id format to urn compatible
 RUN curl -fsSL https://github.com/openedx/credentials/commit/8bc7969fab022625e600f5ba03c70ccda3ccf905.patch | git am
+## Update didkit package to openedx fork
+RUN curl -fsSL https://github.com/openedx/credentials/commit/b157908f5fd7e7b0ed9cb7577bcebb404d625bff.patch | git am
 
 {{ patch("credentials-dockerfile-post-git-checkout") }}
 


### PR DESCRIPTION
### Description

This PR adds the final patch into Ulmo to resolve compatibility issues with the latest version of the LC Wallet: https://github.com/openedx/credentials/issues/2956.

The original PR into credentials: https://github.com/openedx/credentials/pull/2976. This change includes only a package name and version update to openedx fork, which is a drop-in replacement for the original didkit package. The change was tested and proven to be compatible with the 21.0.1 (Ulmo) release for `tutor-credentials`.

