### PR TITLE
Fix/didkit package update patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ instructions, because git commits are used to generate release notes:
 
 - [Bugfix] Add patch with the package update of vc (verifiable credentials) signining lib to openedx fork that is necessary for the vc sharing flow(https://github.com/openedx/credentials/issues/2956). (by @GlugovGrGlib)
 
+- [BugFix] Fix the patch to update didkit package in credentials that was added recently in Dockerfile, credentials build was failing as the commit patch was from master, not from release/ulmo branch. (by @Faraz32123)
+
 <a id='changelog-21.0.1'></a>
 ## v21.0.1 (2026-03-25)
 

--- a/changelog.d/20260402_195333_faraz.maqsood_didkit_package_update_patch.md
+++ b/changelog.d/20260402_195333_faraz.maqsood_didkit_package_update_patch.md
@@ -1,0 +1,1 @@
+- [BugFix] Fix the patch to update didkit package in credentials that was added recently in Dockerfile, credentials build was failing as the commit patch was from master, not from release/ulmo branch. (by @Faraz32123)

--- a/changelog.d/20260402_195333_faraz.maqsood_didkit_package_update_patch.md
+++ b/changelog.d/20260402_195333_faraz.maqsood_didkit_package_update_patch.md
@@ -1,1 +1,0 @@
-- [BugFix] Fix the patch to update didkit package in credentials that was added recently in Dockerfile, credentials build was failing as the commit patch was from master, not from release/ulmo branch. (by @Faraz32123)

--- a/tutorcredentials/templates/credentials/build/credentials/Dockerfile
+++ b/tutorcredentials/templates/credentials/build/credentials/Dockerfile
@@ -57,7 +57,7 @@ RUN curl -fsSL https://github.com/openedx/credentials/commit/0b66761d681faf9e8df
 ## Update obv3 achievement id format to urn compatible
 RUN curl -fsSL https://github.com/openedx/credentials/commit/8bc7969fab022625e600f5ba03c70ccda3ccf905.patch | git am
 ## Update didkit package to openedx fork
-RUN curl -fsSL https://github.com/openedx/credentials/commit/b157908f5fd7e7b0ed9cb7577bcebb404d625bff.patch | git am
+RUN curl -fsSL https://github.com/edly-io/credentials/commit/55be693f74620f964e7bcfe131e3412de934437e.patch | git am
 
 {{ patch("credentials-dockerfile-post-git-checkout") }}
 


### PR DESCRIPTION
In this PR, fix the patch to update didkit package in credentials that was added in https://github.com/overhangio/tutor-credentials/pull/65, credentials build was failing as the commit patch was from master, not from release/ulmo branch.

This change fixes the below error.

```
 => CACHED [code 4/6] RUN curl -fsSL https://github.com/openedx/credentials/commit/0b66761d681faf9e8df5f63  0.0s
 => CACHED [code 5/6] RUN curl -fsSL https://github.com/openedx/credentials/commit/8bc7969fab022625e600f5b  0.0s
 => ERROR [code 6/6] RUN curl -fsSL https://github.com/openedx/credentials/commit/b157908f5fd7e7b0ed9cb757  0.9s
------
 > importing cache manifest from docker.io/overhangio/openedx-credentials:21.0.2-cache:
------
------
 > [code 6/6] RUN curl -fsSL https://github.com/openedx/credentials/commit/b157908f5fd7e7b0ed9cb7577bcebb404d625bff.patch | git am:
0.828 error: patch failed: requirements/base.txt:55
0.828 error: requirements/base.txt: patch does not apply
0.828 error: patch failed: requirements/dev.txt:105
0.828 error: requirements/dev.txt: patch does not apply
0.828 error: patch failed: requirements/production.txt:80
0.828 error: requirements/production.txt: patch does not apply
0.828 error: patch failed: requirements/test.txt:97
0.828 error: requirements/test.txt: patch does not apply
0.828 hint: Use 'git am --show-current-patch=diff' to see the failed patch
0.828 Applying: chore(vc): update didkit package to openedx fork (#2976)
0.828 Patch failed at 0001 chore(vc): update didkit package to openedx fork (#2976)
0.828 When you have resolved this problem, run "git am --continue".
0.828 If you prefer to skip this patch, run "git am --skip" instead.
0.828 To restore the original branch and stop patching, run "git am --abort".
------

 2 warnings found (use --debug to expand):
 - SecretsUsedInArgOrEnv: Do not use ARG or ENV instructions for sensitive data (ARG "CREDENTIALS_REPOSITORY") (line 45)
 - SecretsUsedInArgOrEnv: Do not use ARG or ENV instructions for sensitive data (ENV "CREDENTIALS_CFG") (line 152)
Dockerfile:60
--------------------
  58 |     RUN curl -fsSL https://github.com/openedx/credentials/commit/8bc7969fab022625e600f5ba03c70ccda3ccf905.patch | git am
  59 |     ## Update didkit package to openedx fork
  60 | >>> RUN curl -fsSL https://github.com/openedx/credentials/commit/b157908f5fd7e7b0ed9cb7577bcebb404d625bff.patch | git am
  61 |
  62 |
--------------------
ERROR: failed to solve: process "/bin/sh -c curl -fsSL https://github.com/openedx/credentials/commit/b157908f5fd7e7b0ed9cb7577bcebb404d625bff.patch | git am" did not complete successfully: exit code: 128

View build details: docker-desktop://dashboard/build/desktop-linux/desktop-linux/usxqexttl9ng86zvw0dqgfjy7
Error: Command failed with status 1: docker buildx build --tag=docker.io/overhangio/openedx-credentials:21.0.2 --output=type=docker --cache-from=type=registry,ref=docker.io/overhangio/openedx-credentials:21.0.2-cache /Users/faraz.maqsood/Desktop/test/tutor_env/env/plugins/credentials/build/credentials
```