### PR TITLE
fix: remove patches that were already included in the ulmo.3

### DIFF
--- a/changelog.d/20260528_164607_glugov1998_remove_patches_for_ulmo_3.md
+++ b/changelog.d/20260528_164607_glugov1998_remove_patches_for_ulmo_3.md
@@ -1,0 +1,1 @@
+- [Bugfix] Remove patches for the VC flow that were already backported into release/ulmo.3. (by @GlugovGrGlib)

--- a/tutorcredentials/templates/credentials/build/credentials/Dockerfile
+++ b/tutorcredentials/templates/credentials/build/credentials/Dockerfile
@@ -52,13 +52,6 @@ WORKDIR /openedx/credentials
 RUN git config --global user.email "tutor@overhang.io" \
   && git config --global user.name "Tutor"
 
-## Use URL safe encoding for the status list
-RUN curl -fsSL https://github.com/openedx/credentials/commit/0b66761d681faf9e8df5f63c0e26334d93105aa0.patch | git am
-## Update obv3 achievement id format to urn compatible
-RUN curl -fsSL https://github.com/openedx/credentials/commit/8bc7969fab022625e600f5ba03c70ccda3ccf905.patch | git am
-## Update didkit package to openedx fork
-RUN curl -fsSL https://github.com/edly-io/credentials/commit/55be693f74620f964e7bcfe131e3412de934437e.patch | git am
-
 {{ patch("credentials-dockerfile-post-git-checkout") }}
 
 ###### Install python requirements in virtualenv


### PR DESCRIPTION
## Description

This PR fixes an issue during an image build due to applying patches for commits that are already included in the Ulmo.3 release of the credentials service.

```
Dockerfile:56
--------------------
  54 |
  55 |     ## Use URL safe encoding for the status list
  56 | >>> RUN curl -fsSL https://github.com/openedx/credentials/commit/0b66761d681faf9e8df5f63c0e26334d93105aa0.patch | git am
  57 |     ## Update obv3 achievement id format to urn compatible
  58 |     RUN curl -fsSL https://github.com/openedx/credentials/commit/8bc7969fab022625e600f5ba03c70ccda3ccf905.patch | git am
--------------------
ERROR: failed to build: failed to solve: process "/bin/sh -c curl -fsSL https://github.com/openedx/credentials/commit/0b66761d681faf9e8df5f63c0e26334d93105aa0.patch | git am" did not complete successfully: exit code: 128
```

## Additional notes:
As a workaround before a new version of the tutor-credentials plugin is released the issue can be omitted by setting `CREDENTIALS_REPOSITORY_VERSION: release/ulmo.2` in config.yml.